### PR TITLE
bugfix: Delete sshkeys array rather than elements

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -179,8 +179,8 @@ deleteAllSshkeys() {
     echo "Deleting all sshKeys"
     local TEMPWORK
     TEMPWORK=$(tempwork)
-    jq "del(.os.sshKeys[])" "$WORKCONFIGFILE" > "$TEMPWORK" || finish_up "Could not delete all sshKeys"
-    if [[ "$(jq -e '.os.sshKeys[]' "${TEMPWORK}")" == "" ]] ; then
+    jq "del(.os.sshKeys)" "$WORKCONFIGFILE" > "$TEMPWORK" || finish_up "Could not delete all sshKeys"
+    if [[ "$(jq -e '.os.sshKeys' "${TEMPWORK}")" == null ]] ; then
         mv "${TEMPWORK}" "${WORKCONFIGFILE}" || finish_up "Failed to update working copy of config.json"
     else
 	finish_up "Could not delete all sshKeys"


### PR DESCRIPTION
Delete the os.sshKeys array to align with expectations of balenaOS development-features service for passwordless ssh.

Change-Type: patch